### PR TITLE
Add RFP.ON and RFP.OFF

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -27,6 +27,14 @@ function RFP.BUTTON_ACTION(idBinding, strCommand, tParams)
     end
 end
 
+function RFP.ON(idBinding, strCommand, tParams)
+    SetLightValue(100)
+end
+
+function RFP.OFF(idBinding, strCommand, tParams)
+    SetLightValue(0)
+end
+
 function RFP.DO_PUSH(idBinding, strCommand, tParams)
     --Do nothing for now
 end

--- a/commands.lua
+++ b/commands.lua
@@ -28,11 +28,37 @@ function RFP.BUTTON_ACTION(idBinding, strCommand, tParams)
 end
 
 function RFP.ON(idBinding, strCommand, tParams)
-    SetLightValue(100)
+    local turnOnServiceCall = {
+        domain = "light",
+        service = "turn_on",
+
+        service_data = {},
+
+        target = {
+            entity_id = EntityID
+        }
+    }
+    tParams = {
+        JSON = JSON:encode(turnOnServiceCall)
+    }
+    C4:SendToProxy(999, "HA_CALL_SERVICE", tParams)
 end
 
 function RFP.OFF(idBinding, strCommand, tParams)
-    SetLightValue(0)
+    local turnOnServiceCall = {
+        domain = "light",
+        service = "turn_off",
+
+        service_data = {},
+
+        target = {
+            entity_id = EntityID
+        }
+    }
+    tParams = {
+        JSON = JSON:encode(turnOnServiceCall)
+    }
+    C4:SendToProxy(999, "HA_CALL_SERVICE", tParams)
 end
 
 function RFP.DO_PUSH(idBinding, strCommand, tParams)

--- a/driver.xml
+++ b/driver.xml
@@ -5,8 +5,8 @@
 	<name>HA Light</name>
 	<model>HA Light</model>
 	<created>09/10/2023 12:00</created>
-	<modified>10/22/2023 12:00</modified>
-	<version>105</version>
+	<modified>11/26/2023 12:00</modified>
+	<version>106</version>
 	<control>lua_gen</control>
 	<controlmethod>IP</controlmethod>
 	<driver>DriverWorks</driver>


### PR DESCRIPTION
Add basic ON and OFF commands to allow intuitive inclusion in Macro programming.

The inclusion of these functions allows Light Commands On and Off to work in addition to the already supported Button Command, Top, Single Click and Button Command, Botton, Single Click respectively in Macro programming

<img width="445" alt="Screenshot 2023-11-26 at 11 14 40 AM" src="https://github.com/bphillips09/Control4-HA-Light/assets/8841026/77e32de1-ff7f-475e-8a11-8336bae6eadb">
