### PR TITLE
Enable Advanced Scene Support

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -27,6 +27,14 @@ function RFP.BUTTON_ACTION(idBinding, strCommand, tParams)
     end
 end
 
+function RFP.ON(idBinding, strCommand, tParams)
+    SetLightValue(100)
+end
+
+function RFP.OFF(idBinding, strCommand, tParams)
+    SetLightValue(0)
+end
+
 function RFP.DO_PUSH(idBinding, strCommand, tParams)
     --Do nothing for now
 end

--- a/commands.lua
+++ b/commands.lua
@@ -45,7 +45,7 @@ function RFP.ON(idBinding, strCommand, tParams)
 end
 
 function RFP.OFF(idBinding, strCommand, tParams)
-    local turnOnServiceCall = {
+    local turnOffServiceCall = {
         domain = "light",
         service = "turn_off",
 
@@ -56,7 +56,7 @@ function RFP.OFF(idBinding, strCommand, tParams)
         }
     }
     tParams = {
-        JSON = JSON:encode(turnOnServiceCall)
+        JSON = JSON:encode(turnOffServiceCall)
     }
     C4:SendToProxy(999, "HA_CALL_SERVICE", tParams)
 end

--- a/commands.lua
+++ b/commands.lua
@@ -28,11 +28,37 @@ function RFP.BUTTON_ACTION(idBinding, strCommand, tParams)
 end
 
 function RFP.ON(idBinding, strCommand, tParams)
-    SetLightValue(100)
+    local turnOnServiceCall = {
+        domain = "light",
+        service = "turn_on",
+
+        service_data = {},
+
+        target = {
+            entity_id = EntityID
+        }
+    }
+    tParams = {
+        JSON = JSON:encode(turnOnServiceCall)
+    }
+    C4:SendToProxy(999, "HA_CALL_SERVICE", tParams)
 end
 
 function RFP.OFF(idBinding, strCommand, tParams)
-    SetLightValue(0)
+    local turnOnServiceCall = {
+        domain = "light",
+        service = "turn_off",
+
+        service_data = {},
+
+        target = {
+            entity_id = EntityID
+        }
+    }
+    tParams = {
+        JSON = JSON:encode(turnOnServiceCall)
+    }
+    C4:SendToProxy(999, "HA_CALL_SERVICE", tParams)
 end
 
 function RFP.DO_PUSH(idBinding, strCommand, tParams)

--- a/driver.xml
+++ b/driver.xml
@@ -5,8 +5,8 @@
 	<name>HA Light</name>
 	<model>HA Light</model>
 	<created>09/10/2023 12:00</created>
-	<modified>10/22/2023 12:00</modified>
-	<version>105</version>
+	<modified>11/26/2023 12:00</modified>
+	<version>106</version>
 	<control>lua_gen</control>
 	<controlmethod>IP</controlmethod>
 	<driver>DriverWorks</driver>

--- a/driver.xml
+++ b/driver.xml
@@ -5,7 +5,7 @@
 	<name>HA Light</name>
 	<model>HA Light</model>
 	<created>09/10/2023 12:00</created>
-	<modified>11/26/2023 12:45</modified>
+	<modified>11/26/2023 12:00</modified>
 	<version>107</version>
 	<control>lua_gen</control>
 	<controlmethod>IP</controlmethod>


### PR DESCRIPTION
Enable `advanced_scene_support` capability and implement the minimum functions to support using an HA Light with a level (sent when `supports_target` is false) and brightness (sent when `supports_target` is true) in the scene. 

This patch does not implement colour or brightness rate properties that can be set in advanced lighting. 


<img width="984" src="https://github.com/bphillips09/Control4-HA-Light/assets/8841026/a6646379-b402-46ae-ba4a-0a32aea9489c">


@bphillips09 if you'd rather not have the incomplete implementation on the repo feel free to close the pull request and if I get around to finding a coloured light will put it back up!
